### PR TITLE
Update unit tests to be compatible with Moodle 3.10+

### DIFF
--- a/tests/block_studiosity_test.php
+++ b/tests/block_studiosity_test.php
@@ -38,7 +38,7 @@ class block_studiosity_testcase extends advanced_testcase {
     /**
      * Loads libraries needed to setup tests.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
         global $CFG;
         require_once($CFG->libdir . '/pagelib.php');


### PR DESCRIPTION
In Moodle 3.10 - Breaking change: All the "template methods" (setUp(), tearDown()...) now require to return void.
https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L772